### PR TITLE
Edit release_status output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "release_status" {
   description = "Block status of the deployed release"
-  value       = helm_release.this.metadata
+  value       = helm_release.this[each.key].metadata
 }


### PR DESCRIPTION
Edit the release_status output avoiding this:
Because helm_release.this has "for_each" set, its attributes must be accessed on specific instances. For example, to correlate with indices of a referring resource, use: helm_release.this[each.key] 